### PR TITLE
Expose only configured paths on swagger response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,36 @@ Update appsettings.json:
 }
 ```
 
+## Filtering of Published Paths
+
+If you want to publish only some configured path in YARP, you can use the `AddOnlyPublishedPaths` option.
+Update appsettings.json:
+
+```json lines
+{
+  "ReverseProxy": {
+    "Clusters": {
+      "App1Cluster": {
+        "Destinations": {
+          "Default": {
+            "Address": "https://localhost:5101",
+            "Swaggers": [
+              {
+                "PrefixPath": "/proxy-app1",
+                "AddOnlyPublishedPaths": true, // <-- this line
+                "Paths": [
+                  "/swagger/v1/swagger.json"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 # Contributing
 
 This project welcomes contributions and suggestions through issues and pull requests.

--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
@@ -22,10 +22,12 @@ namespace Yarp.ReverseProxy.Swagger
                     public string PrefixPath { get; init; }
                     public string PathFilterRegexPattern { get; init; }
                     public IReadOnlyList<string> Paths { get; init; }
+
+                    public bool AddOnlyPublishedPaths { get; set; } = false;
                 }
             }
         }
-        
+
         public bool IsEmpty => Clusters?.Any() != true;
     }
 }


### PR DESCRIPTION
Hello Andrei,

I was found your nuget package thank for your effort. I needed to expose only configured routes in swagger. Because our microservices has private endpoints and also we generate client code by swagger. i did not want to add extra code on our client side.

Thats why i have added new configuration in this package.  When AddOnlyPublishedPaths property switch to true in swagger configuration system filter extra routes from swagger.

I hope you can approve my commit and publish new version of the nuget package. we really need to this feature. 

Thanks 
