### PR TITLE
Add components null check in OpenApiExtensions.cs

### DIFF
--- a/src/Yarp.ReverseProxy.Swagger/Extensions/OpenApiExtensions.cs
+++ b/src/Yarp.ReverseProxy.Swagger/Extensions/OpenApiExtensions.cs
@@ -7,6 +7,11 @@ namespace Yarp.ReverseProxy.Swagger.Extensions
     {
         internal static void Add(this OpenApiComponents source, OpenApiComponents components)
         {
+             if (components == null)
+             {
+                 return;
+             }
+            
             foreach (var data in components.Extensions)
             {
                 source.Extensions.TryAdd(data.Key, data.Value);


### PR DESCRIPTION
I had an example of an azure function that only had a get request that returned a string so the returned doc didn't have any.  This check fixes that.