### PR TITLE
Add MetadataPath swagger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,34 @@ Update appsettings.json:
   }
 }
 ```
+
+# Swagger Metadata
+
+If you want to publish the API metadata ([OpenAPI info object](https://swagger.io/specification/#info-object)) from the configured swaggers, specify a path from the list of configured paths using the `MetadataPath` option. This will overwrite the cluster metadata with that of the swagger metadata.
+
+Update appsettings.json:
+
+```json lines
+{
+  "ReverseProxy": {
+    "Clusters": {
+      "App1Cluster": {
+        "Destinations": {
+          "Default": {
+            "Address": "https://localhost:5101",
+            "Swaggers": [
+              {
+                "PrefixPath": "/proxy-app1",
+                "MetadataPath": "/swagger/v1/swagger.json", // <-- this line
+                "Paths": [
+                  "/swagger/v1/swagger.json"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/sample/Yarp/appsettings.json
+++ b/sample/Yarp/appsettings.json
@@ -45,6 +45,7 @@
             "Swaggers": [
               {
                 "PrefixPath": "/proxy-app1",
+                "MetadataPath": "/swagger/v1/swagger.json",
                 "Paths": [
                   "/swagger/v1/swagger.json"
                 ]
@@ -103,6 +104,7 @@
                 ]
               }
             ]
+
           }
         }
       }

--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
@@ -45,6 +45,7 @@ namespace Yarp.ReverseProxy.Swagger
                 return;
             }
 
+            var info = swaggerDoc.Info;
             var paths = new OpenApiPaths();
             var components = new OpenApiComponents();
             var securityRequirements = new List<OpenApiSecurityRequirement>();
@@ -84,7 +85,7 @@ namespace Yarp.ReverseProxy.Swagger
 
                         if (swagger.MetadataPath == swaggerPath)
                         {
-                            swaggerDoc.Info = doc.Info;
+                            info = doc.Info;
                         }
 
                         foreach (var path in doc.Paths)
@@ -131,6 +132,7 @@ namespace Yarp.ReverseProxy.Swagger
                 }
             }
 
+            swaggerDoc.Info = info;
             swaggerDoc.Paths = paths;
             swaggerDoc.SecurityRequirements = securityRequirements;
             swaggerDoc.Components = components;

--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
@@ -82,6 +82,11 @@ namespace Yarp.ReverseProxy.Swagger
                         var stream = httpClient.GetStreamAsync($"{destination.Value.Address}{swaggerPath}").Result;
                         var doc = new OpenApiStreamReader().Read(stream, out _);
 
+                        if (swagger.MetadataPath == swaggerPath)
+                        {
+                            swaggerDoc.Info = doc.Info;
+                        }
+
                         foreach (var path in doc.Paths)
                         {
                             var key = path.Key;

--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
@@ -25,6 +25,7 @@ namespace Yarp.ReverseProxy.Swagger
                     public string PathFilterRegexPattern { get; set; }
                     public IReadOnlyList<string> Paths { get; set; }
                     public bool AddOnlyPublishedPaths { get; set; } = false;
+                    public string MetadataPath { get; set; }
                 }
             }
         }


### PR DESCRIPTION
**Related issues**

Issue #21 

**Describe the pull request**

Adds new and optional `MetadataPath` option in the `appsettings.json` file where you can specify which swagger path to copy over the [OpenAPI info object](https://swagger.io/specification/#info-object) into the generated swagger document.

Since there can be multiple swagger paths, but only one `Info` object for the swagger document, the user must specify which metadata YARP should use.

If the user doesn't want to copy over the API metadata, they can simply not add `MetadataPath` to their `appsettings.json` file, and it will work as it does now.

**Closing issues**
Closes #21