### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ ReverseProxyDocumentFilterConfig GetSwaggerConfig()
 {
     return new ReverseProxyDocumentFilterConfig
     {
+        Routes = GetRoutes().ToDictionary(_ => _.RouteId, _ => _),
         Clusters = new Dictionary<string, ReverseProxyDocumentFilterConfig.Cluster>
         {
             {


### PR DESCRIPTION
**Related issues**
#37 : this PR provide commit with first solution on the issue by updating `Readme` file 


On `Readme` file, In "Code configuration" section, adding the following line:

` Routes = GetRoutes().ToDictionary(_ => _.RouteId, _ => _),`

In version 3.8.0 from the package, Missing setting `Routes` property in `ReverseProxyDocumentFilterConfig` cause a Null pointer exception, for earlier version this wasn't an issue it could be null. 

this related to the new function that interduce in `ReverseProxyDocumentFilter` class: `ApplySwaggerTransformation()`

The following in the exception details:

```
System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
System.Linq.Enumerable.Where<TSource>(IEnumerable<TSource> source, Func<TSource, bool> predicate)
Yarp.ReverseProxy.Swagger.ReverseProxyDocumentFilter.ApplySwaggerTransformation(List<OperationType> operationKeys, KeyValuePair<string, OpenApiPathItem> path, string clusterKey)
Yarp.ReverseProxy.Swagger.ReverseProxyDocumentFilter.Apply(OpenApiDocument swaggerDoc, IReadOnlyDictionary<string, Cluster> clusters)
Yarp.ReverseProxy.Swagger.ReverseProxyDocumentFilter.Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GetSwaggerAsync(string documentName, string host, string basePath)
Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)
```