### PR TITLE
Added missing override when manually providing config

### DIFF
--- a/src/Yarp.ReverseProxy.Swagger/Extensions/ReverseProxyBuilderExtensions.cs
+++ b/src/Yarp.ReverseProxy.Swagger/Extensions/ReverseProxyBuilderExtensions.cs
@@ -33,6 +33,7 @@ namespace Yarp.ReverseProxy.Swagger.Extensions
             {
                 overriddenConfig.Routes = config.Routes;
                 overriddenConfig.Clusters = config.Clusters;
+                overriddenConfig.Swagger = config.Swagger;
             });
 
             ConfigureHttpClient(builder, config);


### PR DESCRIPTION
**Related issues**

While implementing some manual config loading, I noticed that the `AddSwagger(...)` Method in `ReverseProxyBuilderExtensions.cs` ignored the provided Swagger-Part of the `ReverseProxyDocumentFilterConfig`

**Describe the pull request**

I added the imo missing line

**Closing issues**

Didn't bother to open an issue for that 😄 
