### PR TITLE
Handle duplicate schemas when using common document

### DIFF
--- a/src/Yarp.ReverseProxy.Swagger/Extensions/OpenApiExtensions.cs
+++ b/src/Yarp.ReverseProxy.Swagger/Extensions/OpenApiExtensions.cs
@@ -5,7 +5,7 @@ namespace Yarp.ReverseProxy.Swagger.Extensions
 {
     public static class OpenApiExtensions
     {
-        internal static void Add(this OpenApiComponents source, OpenApiComponents components, bool renameDuplicateComponents = false)
+        internal static void Add(this OpenApiComponents source, OpenApiComponents components, bool renameDuplicateSchemas = false)
         {
             if (components == null)
             {
@@ -31,7 +31,7 @@ namespace Yarp.ReverseProxy.Swagger.Extensions
             {
                 bool added = source.Schemas.TryAdd(data.Key, data.Value);
                 int i = 1;
-                while(!added && renameDuplicateComponents)
+                while(!added && renameDuplicateSchemas)
                 {
                     i++;
                     var key = $"{data.Key}{i}";

--- a/src/Yarp.ReverseProxy.Swagger/Extensions/OpenApiExtensions.cs
+++ b/src/Yarp.ReverseProxy.Swagger/Extensions/OpenApiExtensions.cs
@@ -34,8 +34,9 @@ namespace Yarp.ReverseProxy.Swagger.Extensions
                 while(!added && renameDuplicateComponents)
                 {
                     i++;
-                    data.Value.Reference.Id = $"{data.Key}{i}";
-                    added = source.Schemas.TryAdd($"{data.Key}{i}", data.Value);
+                    var key = $"{data.Key}{i}";
+                    data.Value.Reference.Id = key;
+                    added = source.Schemas.TryAdd(key, data.Value);
                 }
             }
 

--- a/src/Yarp.ReverseProxy.Swagger/Extensions/OpenApiExtensions.cs
+++ b/src/Yarp.ReverseProxy.Swagger/Extensions/OpenApiExtensions.cs
@@ -5,7 +5,7 @@ namespace Yarp.ReverseProxy.Swagger.Extensions
 {
     public static class OpenApiExtensions
     {
-        internal static void Add(this OpenApiComponents source, OpenApiComponents components)
+        internal static void Add(this OpenApiComponents source, OpenApiComponents components, bool renameDuplicateComponents = false)
         {
             if (components == null)
             {
@@ -29,7 +29,14 @@ namespace Yarp.ReverseProxy.Swagger.Extensions
 
             foreach (var data in components.Schemas)
             {
-                source.Schemas.TryAdd(data.Key, data.Value);
+                bool added = source.Schemas.TryAdd(data.Key, data.Value);
+                int i = 1;
+                while(!added && renameDuplicateComponents)
+                {
+                    i++;
+                    data.Value.Reference.Id = $"{data.Key}{i}";
+                    added = source.Schemas.TryAdd($"{data.Key}{i}", data.Value);
+                }
             }
 
             foreach (var data in components.SecuritySchemes)

--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
@@ -173,7 +173,7 @@ namespace Yarp.ReverseProxy.Swagger
                                 paths.TryAdd($"{swagger.PrefixPath}{key}", value);
                             }
 
-                            components.Add(doc.Components, config.Swagger.RenameDuplicateComponents);
+                            components.Add(doc.Components, config.Swagger.RenameDuplicateSchemas);
                             securityRequirements.AddRange(doc.SecurityRequirements);
                             tags.AddRange(doc.Tags);
                         }

--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
@@ -173,7 +173,7 @@ namespace Yarp.ReverseProxy.Swagger
                                 paths.TryAdd($"{swagger.PrefixPath}{key}", value);
                             }
 
-                            components.Add(doc.Components);
+                            components.Add(doc.Components, config.Swagger.RenameDuplicateComponents);
                             securityRequirements.AddRange(doc.SecurityRequirements);
                             tags.AddRange(doc.Tags);
                         }

--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
@@ -35,7 +35,7 @@ namespace Yarp.ReverseProxy.Swagger
         {
             public bool IsCommonDocument { get; set; } = false;
             public string CommonDocumentName { get; set; } = "YARP";
-            public bool RenameDuplicateComponents { get; set; } = false;
+            public bool RenameDuplicateSchemas { get; set; } = false;
         }
 
         public bool IsEmpty => Clusters?.Any() != true;

--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
@@ -35,6 +35,7 @@ namespace Yarp.ReverseProxy.Swagger
         {
             public bool IsCommonDocument { get; set; } = false;
             public string CommonDocumentName { get; set; } = "YARP";
+            public bool RenameDuplicateComponents { get; set; } = false;
         }
 
         public bool IsEmpty => Clusters?.Any() != true;


### PR DESCRIPTION
We are starting to transition our microservices to YARP but that has come with some challenges of us having duplicate classes spread across our system. To help our transition, I implemented a way to automatically rename schemas that have already appeared before.

This does not check to see if all properties are the same before attempting to rename an already added schema
