### PR TITLE
Combining duplicate schemas

### DIFF
--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
@@ -179,7 +179,7 @@ namespace Yarp.ReverseProxy.Swagger
                                 paths.TryAdd($"{swagger.PrefixPath}{key}", value);
                             }
 
-                            components.Add(doc.Components, config.Swagger.RenameDuplicateSchemas);
+                            components.Add(doc.Components, config.Swagger.DuplicateSchemas);
                             securityRequirements.AddRange(doc.SecurityRequirements);
                             tags.AddRange(doc.Tags);
                         }

--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilterConfig.cs
@@ -35,7 +35,7 @@ namespace Yarp.ReverseProxy.Swagger
         {
             public bool IsCommonDocument { get; set; } = false;
             public string CommonDocumentName { get; set; } = "YARP";
-            public bool RenameDuplicateSchemas { get; set; } = false;
+            public string DuplicateSchemas { get; set; } = "First";
         }
 
         public bool IsEmpty => Clusters?.Any() != true;


### PR DESCRIPTION
Following up with @waynebowie99 's changes, this gives the option to combine the properties of duplicate classes so they will still be one class. Mismatched properties are set to be nullable, since they may not exist on a get.

You can set how you'd like to handle the duplicate schemas in the app settings, with the default being "First", in which only the first class is added. (How the main branch works now)
