### PR TITLE
Fix a null reference exception when upstream openapi documents have no tags

### DIFF
--- a/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
+++ b/src/Yarp.ReverseProxy.Swagger/ReverseProxyDocumentFilter.cs
@@ -193,11 +193,16 @@ namespace Yarp.ReverseProxy.Swagger
                             }
 
                             components.Add(doc.Components, config.Swagger.RenameDuplicateSchemas);
-                            if(doc.Security != null)
+
+                            if (doc.Security != null)
                             {
                                 securityRequirements.AddRange(doc.Security);
                             }
-                            tags.AddRange(doc.Tags);
+
+                            if (doc.Tags != null)
+                            {
+                                tags.AddRange(doc.Tags);
+                            }
                         }
                     }
                 }

--- a/src/Yarp.ReverseProxy.Swagger/Yarp.ReverseProxy.Swagger.csproj
+++ b/src/Yarp.ReverseProxy.Swagger/Yarp.ReverseProxy.Swagger.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net10.0</TargetFrameworks>
 		<PackageId>Treyt.Yarp.ReverseProxy.Swagger</PackageId>
-		<Version>4.0.0</Version>
+		<Version>4.0.1</Version>
 		<Authors>Andrei Tsaregorodtsev</Authors>
 		<PackageProjectUrl>https://github.com/andreytreyt/yarp-swagger</PackageProjectUrl>
 	</PropertyGroup>


### PR DESCRIPTION
**Related issues**

- https://github.com/andreytreyt/yarp-swagger/issues/53

**Describe the pull request**

Fixes a null reference exception (introduced with v4.0.0) when the upstream OpenAPI document has no tags. 

**Changes made**

- Added null check before assigning tags to swaggerDoc.Tags

**Closing issues**

- `Closes #53`
